### PR TITLE
fix: use PUPPETEER_SKIP_DOWNLOAD in deploy workflows

### DIFF
--- a/.github/workflows/deploy-s3-dev.yml
+++ b/.github/workflows/deploy-s3-dev.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install Dependencies
         env:
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+          PUPPETEER_SKIP_DOWNLOAD: "true"
         run: npm i
 
       - name: Build

--- a/.github/workflows/deploy-s3-prod.yml
+++ b/.github/workflows/deploy-s3-prod.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install Dependencies
         env:
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+          PUPPETEER_SKIP_DOWNLOAD: "true"
         run: npm i
 
       - name: Build


### PR DESCRIPTION
PUPPETEER_SKIP_CHROMIUM_DOWNLOAD is not read by Puppeteer 21+, so npm i was downloading Chromium on every deploy and hanging past the job's timeout-minutes (confirmed on the dev pipeline run 28939125376, which never shipped). Matches the same fix already applied to ci.yml.